### PR TITLE
Use a valid SPDX license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
         "email" : "mail@substack.net",
         "url" : "http://substack.net"
     },
-    "license" : "MIT/X11",
+    "license" : "MIT",
     "engine" : { "node" : ">=0.4" }
 }


### PR DESCRIPTION
Sorry for the tiny patch. As it turns out, just `"MIT"` (not `"MIT/X11"`) is the [standard-compliant way](http://spdx.org/licenses) of identifying the license. It's what `npm help 7 package.json` recommends, but so far word hasn't got around ... about the help page of the standard.

I noticed that a few of your other very popular modules use `"MIT/X11"` rather than `"MIT"`, including node-charm, node-optimist, and node-seq. Let me know if you'd like PRs to push-button merge for those, as well. I've scripts to do the job automagically, which I've been using to auto-preach the gospel more widely, so it's no trouble. But I didn't want to hit you with a ton of robo-PRs without asking.

Working on adding validation to `npm` itself, by the by.